### PR TITLE
Ruby 1.9 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - 2.0.0
+  - 1.9.3
 script:
   - bundle exec rake spec

--- a/lib/easy_app_helper/core/base.rb
+++ b/lib/easy_app_helper/core/base.rb
@@ -20,7 +20,7 @@ class EasyAppHelper::Core::Base
   def initialize(logger)
     @app_name = @app_version = @app_description = ""
     @script_filename = File.basename $0, '.*'
-    @internal_configs = {modified: {content: {}, source: CHANGED_BY_CODE}}
+    @internal_configs = {:modified => {:content => {}, :source => CHANGED_BY_CODE}}
     @logger = logger
     @slop_definition = Slop.new
     build_command_line_options
@@ -63,7 +63,7 @@ class EasyAppHelper::Core::Base
   # @param [String] script_filename
   # @param [String] app_version
   # @param [String] app_description
-  def describes_application(app_name: nil, script_filename: nil, app_version: nil, app_description: nil)
+  def describes_application(app_name = nil, script_filename = nil, app_version = nil, app_description = nil)
     self.app_name = app_name unless app_name.nil?
     self.app_version = app_version unless app_version.nil?
     self.app_description = app_description unless app_description.nil?
@@ -100,7 +100,7 @@ class EasyAppHelper::Core::Base
       return
     end
     unless layers.include? layer
-      internal_configs[layer] = {content: {}, source: 'Unknown source'}
+      internal_configs[layer] = {:content => {}, :source => 'Unknown source'}
       logger.warn "Trying to modify a non existing config layer: \"#{layer.to_s}\". Automatically creating it..."
     end
     internal_configs[layer][:content][key] = value
@@ -130,7 +130,7 @@ class EasyAppHelper::Core::Base
 
   # Reset the :modified layer of internal_configs rolling back any change done to the config
   def reset
-    internal_configs[:modified] = {content: {}, source: CHANGED_BY_CODE}
+    internal_configs[:modified] = {:content => {}, :source => CHANGED_BY_CODE}
     self
   end
 
@@ -180,7 +180,7 @@ class EasyAppHelper::Core::Base
   private
 
   def sync!
-    internal_configs[:command_line] = {content: command_line_config, source: 'Command line'}
+    internal_configs[:command_line] = {:content => command_line_config, :source => 'Command line'}
   end
 
 

--- a/lib/easy_app_helper/core/config.rb
+++ b/lib/easy_app_helper/core/config.rb
@@ -163,7 +163,7 @@ class EasyAppHelper::Core::Config
   # Actual loads
   def fetch_config_layer(layer, filename_or_pattern)
     if filename_or_pattern.nil?
-      internal_configs[layer] = {content: {}}
+      internal_configs[layer] = {:content => {}}
       filename = nil
     else
       if File.exists? filename_or_pattern and !File.directory? filename_or_pattern
@@ -172,7 +172,7 @@ class EasyAppHelper::Core::Config
         places = Places.possible_config_places[layer]
         filename = find_file places, filename_or_pattern
       end
-      internal_configs[layer] = {content: load_config_file(filename, layer), source: filename, origin: filename_or_pattern}
+      internal_configs[layer] = {:content => load_config_file(filename, layer), :source => filename, :origin => filename_or_pattern}
     end
   ensure
     logger.info "No config file found for layer #{layer}." if filename.nil?

--- a/lib/easy_app_helper/core/places.rb
+++ b/lib/easy_app_helper/core/places.rb
@@ -16,34 +16,34 @@ module EasyAppHelper
       module Places
 
         OS_FLAVOURS = {
-            mingw32: :windows,
-            linux: :unix
+            :mingw32 => :windows,
+            :linux => :unix
         }
         DEFAULT_OS_FLAVOUR = :unix
 
         FLAVOUR_PLACES = {
-            unix: {
-                internal: [],
+            :unix => {
+                :internal => [],
 
-                system: ['/etc'],
+                :system => ['/etc'],
 
                 # Where could be stored global wide configuration
-                global: %w(/etc /usr/local/etc),
+                :global => %w(/etc /usr/local/etc),
 
                 # Where could be stored user configuration
-                user:  ["#{ENV['HOME']}/.config"]
+                :user =>  ["#{ENV['HOME']}/.config"]
             },
-            windows: {
-                internal: [],
+            :windows => {
+                :internal => [],
 
-                system: ["#{ENV['systemRoot']}/Config"],
+                :system => ["#{ENV['systemRoot']}/Config"],
 
                 # Where could be stored global configuration
-                global: ["#{ENV['systemRoot']}/Config",
+                :global => ["#{ENV['systemRoot']}/Config",
                          "#{ENV['ALLUSERSPROFILE']}/Application Data"],
 
                 # Where could be stored user configuration
-                user: [ENV['APPDATA']]
+                :user => [ENV['APPDATA']]
             }
         }
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -78,7 +78,7 @@ describe "The EasyAppHelper config object" do
           end
         end
 
-        it test_descr, layers: layers.dup  do
+        it test_descr, :layers => layers.dup  do
           layers = example.metadata[:layers]
           expect(subject.find_layer :basic_test).to eq layer
           expect(subject[:basic_test]).to eq "#{SAMPLE_STRING} #{layer.to_s}"
@@ -180,7 +180,7 @@ describe "The EasyAppHelper config object" do
 
     it 'should have the same content using #command_line_config and #internal_configs[:command_line][:content]' do
       subject.add_command_line_section('Scripts analysis') do |slop|
-        slop.on :p, :pipo, 'Directory path where SQL files are located.', argument: false
+        slop.on :p, :pipo, 'Directory path where SQL files are located.', :argument => false
       end
       expect(subject.command_line_config).to eq subject.internal_configs[:command_line][:content]
     end

--- a/test/test4_app.rb
+++ b/test/test4_app.rb
@@ -15,7 +15,7 @@ class MyApp
 
   def initialize
     # Providing this data is optional
-    config.describes_application(app_name: APP_NAME, app_version: VERSION, app_description: DESCRIPTION)
+    config.describes_application(:app_name => APP_NAME, :app_version => VERSION, :app_description => DESCRIPTION)
     add_cmd_line_options
   end
 


### PR DESCRIPTION
I had the necessity for  `easy_app_helper` to run on ruby1.9 for my arm based machine (raspi).

This PR adds ruby 1.9 compatibility
