### PR TITLE
Read original directory from Task context to find current gem

### DIFF
--- a/lib/tasks/easy_app_helper_tasks.rake
+++ b/lib/tasks/easy_app_helper_tasks.rake
@@ -10,7 +10,7 @@ namespace :easy_app_helper do
   desc 'create automatically a new executable in "bin" from a template. Default name is Gem name'
   task :create_executable, [:executable_name] do |tsk, args|
     script_content = build_executable args[:executable_name]
-    bin_dir = check_bin_dir
+    bin_dir = check_bin_dir tsk
     script_name = File.join bin_dir, executable_name
     if File.exists? script_name
       STDERR.puts "File '#{script_name}' already exists !\n -> Aborted."

--- a/lib/tasks/template_manager.rb
+++ b/lib/tasks/template_manager.rb
@@ -14,8 +14,8 @@ module EasyAppHelper
         File.read TEMPLATE
       end
 
-      def check_bin_dir
-        spec = current_gem_spec
+      def check_bin_dir(task = nil)
+        spec = current_gem_spec task
         rel_bin_dir = spec.bindir.empty? ? 'bin' : spec.bindir
         bin_dir = Dir.exists?(spec.bin_dir) ? spec.bin_dir : File.join(spec.full_gem_path, rel_bin_dir)
         FileUtils.mkdir bin_dir unless Dir.exists? bin_dir
@@ -34,7 +34,7 @@ module EasyAppHelper
         script = renderer.result binding
       end
 
-      def current_gem_spec
+      def current_gem_spec(task = nil)
         searcher = if Gem::Specification.respond_to? :find
                      # ruby 2.0
                      Gem::Specification
@@ -44,7 +44,8 @@ module EasyAppHelper
                    end
         unless searcher.nil?
           searcher.find do |spec|
-            File.fnmatch(File.join(spec.full_gem_path,'*'), __FILE__)
+            original_file = task ? File.join(task.application.original_dir, task.application.rakefile) : __FILE__
+            File.fnmatch(File.join(spec.full_gem_path,'*'), original_file)
           end
         end
       end


### PR DESCRIPTION
In order to find the current gem's directory, I read the information from the current task being executed.

Unfortunaly, this patch will not work for the "test" gem that is inside EAH's path as the `File.fnmatch` will match for any gem inside EAH's path.

As discussed previously, I thought we could get some context directly from the task! What you think about it?