### PR TITLE
Added the possibility to process processes output live

### DIFF
--- a/lib/easy_app_helper.rb
+++ b/lib/easy_app_helper.rb
@@ -28,12 +28,12 @@ module EasyAppHelper
     end
   end
 
-  def safely_exec_command(message, command, show_output = false, log_output = true)
+  def safely_exec_command(message, command, show_output = false, log_output = true, &log_processor)
     safely_exec_code message, command, show_output, log_output do |command, show_output, log_output|
       process = EasyAppHelper::Processes::Base.new command
       process.show_output = show_output
       process.log_output = log_output
-      process.execute
+      process.execute &log_processor
       process
     end
   end

--- a/lib/easy_app_helper/processes/synchronous.rb
+++ b/lib/easy_app_helper/processes/synchronous.rb
@@ -3,7 +3,7 @@ module EasyAppHelper
 
     module Synchronous
 
-      def execute
+      def execute(&log_processor)
         self.exit_status = nil
         self.last_pid = nil
         self.process_state = :running
@@ -22,6 +22,7 @@ module EasyAppHelper
                   begin
                     buffer = ''
                     buffer << io.read_nonblock(1) while buffer[-1] != "\n"
+                    log_processor.call buffer if block_given?
                     report buffer, io == stdout
                   rescue IO::WaitReadable
                     next


### PR DESCRIPTION
When a synchronous process is started (the only one supported up to now), its output could be:
* logged
* echoed

Now they can has well be processed _live_ by passing a block to `safely_exec_command`.