### PR TITLE
Feature/new stacked config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.0.0-p648
   - 2.2.4
 script:
   - bundle exec rspec -f d 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -21,11 +21,22 @@ and as unobtrusive as possible (you choose when you want to include or use as a 
 a ready-for-prod config, logger and command line management.
 
 
+:warning: Versions prior to `4.0.0` were trying to give an indifferent access to the merged config for strings
+and symbols, ie `EasyAppHelper.config[:an_entry]` was giving the same result as `EasyAppHelper.config['an_entry']`.
+
+This is clearly wrong and not consistent everywhere and 
+__starting with version `4.0.0` this is no more the case__. Please check [stacked_config](https://github.com/lbriais/stacked_config/blob/master/README.md#between-version-1x-and-2x)
+for more information. If you want to keep previous behaviour you should specify to continue using the old version
+using the '~> 3.0' operator (also known as the 
+[pessimistic version constraint](http://guides.rubygems.org/patterns/#pessimistic-version-constraint)).
+
+
+
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'easy_app_helper', '~> 3.0'
+    gem 'easy_app_helper', '~> 4.0'
 
 And then execute:
 

--- a/easy_app_helper.gemspec
+++ b/easy_app_helper.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'activesupport'
-  spec.add_runtime_dependency 'stacked_config', '~> 1.2.2'
+  spec.add_runtime_dependency 'stacked_config', '~> 2.0.0'
 end


### PR DESCRIPTION
Non backward compatible changes for version 4.x as migrating to `stacked_config` gem 2.x...
See https://github.com/lbriais/stacked_config/blob/master/README.md#between-version-1x-and-2x for more information